### PR TITLE
apt-get updateを削除して立ち上がらなくなったので修正

### DIFF
--- a/kuzushiji-generator/Dockerfile
+++ b/kuzushiji-generator/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8
 
-RUN apt-get -y install locales && \
+RUN apt-get update && \
+    apt-get -y install locales && \
     localedef -f UTF-8 -i ja_JP ja_JP.UTF-8
 
 RUN mkdir /code


### PR DESCRIPTION
apt-get updateは避けるべきって公式に書いてあったが、誤訳だったらしい